### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ThPullRefresh
 * swift 快速集成下拉刷新，上拉加载更多功能.<br />
 如何使用：<br />
-Cocoapods 导入：pod 'ThPullRefresh'，<br />
+CocoaPods 导入：pod 'ThPullRefresh'，<br />
 		在项目中 import 'ThPullRefresh'<br />
 手动导入：将'ThPullRefresh' 文件夹中的所有文件拽入项目中<br />
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
